### PR TITLE
Update references from "supplier" to "partner"

### DIFF
--- a/nda-backend/database/queries.rs
+++ b/nda-backend/database/queries.rs
@@ -3,17 +3,17 @@
 pub async fn find_process_share(
     pool: &SqlitePool,
     process_id: &str,
-    supplier_public_key: &str,
+    partner_public_key: &str,
 ) -> Result<Option<ProcessShare>, sqlx::Error> {
     let share = sqlx::query_as!(
         ProcessShare,
         r#"
-        SELECT id, process_id, supplier_public_key, stellar_transaction_hash, shared_at
+        SELECT id, process_id, partner_public_key, stellar_transaction_hash, shared_at
         FROM process_shares 
-        WHERE process_id = ? AND supplier_public_key = ?
+        WHERE process_id = ? AND partner_public_key = ?
         "#,
         process_id,
-        supplier_public_key
+        partner_public_key
     )
     .fetch_optional(pool)
     .await?;

--- a/nda-backend/src/handlers.rs
+++ b/nda-backend/src/handlers.rs
@@ -41,7 +41,7 @@
 //! - **Role-Based Access Control**: Endpoints verify user roles before operations
 //! - **AES-256-GCM Encryption**: All process content is encrypted with unique keys
 //! - **Blockchain Verification**: Process sharing is recorded on Stellar network
-//! - **Access Control**: Suppliers can only access processes explicitly shared with them
+//! - **Access Control**: Partners can only access processes explicitly shared with them
 //! - **Complete Audit Trail**: All access events are logged for compliance
 //! 
 //! ## Updated Request Flow Example

--- a/nda-backend/src/models.rs
+++ b/nda-backend/src/models.rs
@@ -114,7 +114,7 @@ pub struct User {
     pub stellar_public_key: String,
     pub stellar_secret_key: String, // In production, use KMS (Key Management Service)
     pub password_hash: String, // Bcrypt hashed password
-    pub roles: String, // JSON string: ["client"] | ["supplier"] | ["client","supplier"]
+    pub roles: String, // JSON string: ["client"] | ["partner"] | ["client","partner"]
     pub created_at: DateTime<Utc>,
 }
 
@@ -137,7 +137,7 @@ impl std::fmt::Debug for User {
 /// NDA process with encrypted confidential content.
 /// 
 /// Represents a Non-Disclosure Agreement process containing encrypted sensitive
-/// information that can be selectively shared with suppliers via blockchain transactions.
+/// information that can be selectively shared with partners via blockchain transactions.
 /// 
 /// # Fields
 /// 
@@ -160,8 +160,8 @@ impl std::fmt::Debug for User {
 /// # Lifecycle
 /// 
 /// 1. **Creation**: Client creates process with encrypted content
-/// 2. **Sharing**: Client shares with suppliers via Stellar blockchain transaction
-/// 3. **Access**: Suppliers decrypt and access content with proper authorization
+/// 2. **Sharing**: Client shares with partners via Stellar blockchain transaction
+/// 3. **Access**: Partners decrypt and access content with proper authorization
 /// 4. **Audit**: All access events are logged for compliance reporting
 #[derive(Debug, Serialize, Deserialize, FromRow)]
 pub struct Process {
@@ -310,7 +310,7 @@ pub struct ProcessAccessWithDetails {
 /// {
 ///   "username": "john_doe",
 ///   "password": "secure_password",
-///   "roles": ["client", "supplier"]
+///   "roles": ["client", "partner"]
 /// }
 /// ```
 #[derive(Debug, Deserialize)]
@@ -505,18 +505,18 @@ pub struct UserResponse {
 ///     username: "john_doe".to_string(),
 ///     stellar_public_key: "GABC...".to_string(),
 ///     stellar_secret_key: "SABC...".to_string(),
-///     roles: r#"["client","supplier"]"#.to_string(),
+///     roles: r#"["client","partner"]"#.to_string(),
 ///     created_at: chrono::Utc::now(),
 /// };
 /// let response: UserResponse = user.into();
-/// assert_eq!(response.roles, vec!["client", "supplier"]);
+/// assert_eq!(response.roles, vec!["client", "partner"]);
 /// ```
 impl User {
     /// Checks if the user has a specific role.
     /// 
     /// # Parameters
     /// 
-    /// * `role` - The role to check for ("client" or "supplier")
+    /// * `role` - The role to check for ("client" or "partner")
     /// 
     /// # Returns
     /// 
@@ -563,15 +563,6 @@ impl User {
         self.has_role("partner")
     }
 
-    /// Legacy method for backwards compatibility.
-    /// 
-    /// # Deprecated
-    /// Use `is_partner()` instead. This method will be removed in a future version.
-    #[deprecated(since = "1.0.0", note = "Use `is_partner()` instead")]
-    pub fn is_supplier(&self) -> bool {
-        self.is_partner()
-    }
-    
     /// Gets all roles assigned to the user.
     /// 
     /// # Returns
@@ -686,7 +677,7 @@ impl From<Process> for ProcessResponse {
 /// Decrypted process content for authorized access responses.
 /// 
 /// Contains the decrypted confidential content that is returned when
-/// a supplier successfully accesses a shared process. This response
+/// a partner successfully accesses a shared process. This response
 /// is only generated after proper authorization verification.
 /// 
 /// # Fields
@@ -706,7 +697,7 @@ impl From<Process> for ProcessResponse {
 /// # Usage Context
 /// 
 /// This model is used exclusively for successful process access operations
-/// where the supplier has proven authorization to view the content.
+/// where the partner has proven authorization to view the content.
 #[derive(Debug, Serialize)]
 pub struct ProcessAccessResponse {
     pub process_id: String,

--- a/nda-backend/src/stellar_real.rs
+++ b/nda-backend/src/stellar_real.rs
@@ -72,7 +72,7 @@
 //! // Share a process via blockchain
 //! let tx_result = client.share_process_transaction(
 //!     &account.secret_key,
-//!     &supplier_public_key,
+//!     &partner_public_key,
 //!     &process_id,
 //!     "NDA_SHARE"
 //! ).await?;
@@ -80,7 +80,7 @@
 //! // Verify access permissions
 //! let has_access = client.verify_process_access(
 //!     &process_id,
-//!     &supplier_public_key
+//!     &partner_public_key
 //! ).await?;
 //! ```
 //! 
@@ -563,7 +563,7 @@ impl StellarClient {
     /// ```rust
     /// let tx_result = client.share_process_transaction(
     ///     &client_secret_key,
-    ///     &supplier_public_key,
+    ///     &partner_public_key,
     ///     &process_id,
     ///     "NDA_SHARE:confidential_project"
     /// ).await?;
@@ -640,7 +640,7 @@ impl StellarClient {
     /// ```rust
     /// let has_access = client.verify_process_access(
     ///     &process_id,
-    ///     &supplier_public_key
+    ///     &partner_public_key
     /// ).await?;
     /// 
     /// if has_access {

--- a/nda-manager/src/app/components/list-contracts/list-contracts.component.html
+++ b/nda-manager/src/app/components/list-contracts/list-contracts.component.html
@@ -60,7 +60,7 @@
             <th>Title / ID</th>
             <th>Description</th>
             <th>Status</th>
-            <th>Supplier ID</th>
+            <th>Partner ID</th>
             <th>Data</th>
             <th>Actions</th>
           </tr>
@@ -90,9 +90,9 @@
                 </span>
               </td>
               
-              <!-- Supplier ID -->
-              <td class="supplier-cell">
-                <span class="supplier-id">{{ contract.supplierId || 'N/A' }}</span>
+              <!-- Partner ID -->
+              <td class="partner-cell">
+                <span class="partner-id">{{ contract.partnerId || 'N/A' }}</span>
               </td>
               
               <!-- Data -->

--- a/nda-manager/src/app/components/list-contracts/list-contracts.component.scss
+++ b/nda-manager/src/app/components/list-contracts/list-contracts.component.scss
@@ -215,10 +215,10 @@
   }
 }
 
-.client-cell, .supplier-cell {
+.client-cell, .partner-cell {
   min-width: 120px;
   
-  .client-id, .supplier-id {
+  .client-id, .partner-id {
     font-family: monospace;
     font-size: 0.875rem;
     color: #374151;

--- a/nda-manager/src/app/components/list-contracts/list-contracts.component.ts
+++ b/nda-manager/src/app/components/list-contracts/list-contracts.component.ts
@@ -53,7 +53,7 @@ Contract Information:
 - Title: ${contract.title}
 - Status: ${contract.status}
 - Client ID: ${contract.clientId}
-- Supplier ID: ${contract.supplierId}
+- Partner ID: ${contract.partnerId}
     `.trim();
 
     navigator.clipboard.writeText(info).then(() => {

--- a/nda-manager/src/app/components/menu/menu.component.ts
+++ b/nda-manager/src/app/components/menu/menu.component.ts
@@ -203,16 +203,16 @@ export class MenuComponent implements OnInit, OnDestroy {
       if (this.isClient && this.isSupplier) {
         // Se tem múltiplas roles, remover uma
         if (this.isClient) {
-          newRoles = ['supplier'];
+          newRoles = ['partner'];
         } else {
           newRoles = ['client'];
         }
       } else if (this.isClient) {
-        // Se é só cliente, adicionar supplier
-        newRoles = ['client', 'supplier'];
+        // Se é só cliente, adicionar partner
+        newRoles = ['client', 'partner'];
       } else if (this.isSupplier) {
-        // Se é só supplier, adicionar client
-        newRoles = ['client', 'supplier'];
+        // Se é só partner, adicionar client
+        newRoles = ['client', 'partner'];
       } else {
         // Fallback - definir como cliente
         newRoles = ['client'];

--- a/nda-manager/src/app/components/menu/menu.component.ts
+++ b/nda-manager/src/app/components/menu/menu.component.ts
@@ -51,7 +51,7 @@ export class MenuComponent implements OnInit, OnDestroy {
   
   // ✅ NOVO: Propriedades para o novo sistema de roles
   isClient = false;
-  isSupplier = false;
+  isPartner = false;
   hasMultipleRoles = false;
 
   ngOnInit() {
@@ -63,21 +63,21 @@ export class MenuComponent implements OnInit, OnDestroy {
     if (currentClient) {
       // Atualizar propriedades baseadas em roles
       this.isClient = currentClient.isClient();
-      this.isSupplier = currentClient.isSupplier();
-      this.hasMultipleRoles = this.isClient && this.isSupplier;
+      this.isPartner = currentClient.isPartner();
+      this.hasMultipleRoles = this.isClient && this.isPartner;
       
       // Atualizar permissões baseadas em roles
       this.canCreateContracts = this.isClient;
-      this.canShareContracts = this.isSupplier;
+      this.canShareContracts = this.isPartner;
       
       this.contractService.getPermissions().subscribe(permissions => {
         this.canCreateContracts = permissions.canCreate && this.isClient;
-        this.canShareContracts = permissions.canShare && this.isSupplier;
+        this.canShareContracts = permissions.canShare && this.isPartner;
       });
     } else {
       // Fallback se não houver usuário logado
       this.isClient = false;
-      this.isSupplier = false;
+      this.isPartner = false;
       this.hasMultipleRoles = false;
       this.canCreateContracts = false;
       this.canShareContracts = false;
@@ -85,7 +85,7 @@ export class MenuComponent implements OnInit, OnDestroy {
 
     console.log('👤 Client loaded:', currentClient);
     console.log('🔑 Is Client:', this.isClient);
-    console.log('🏭 Is Supplier:', this.isSupplier);
+    console.log('🏭 Is Partner:', this.isPartner);
     console.log('🔄 Has Multiple Roles:', this.hasMultipleRoles);
     console.log('🔨 Can create contracts:', this.canCreateContracts);
     console.log('🔗 Can share contracts:', this.canShareContracts);
@@ -99,7 +99,7 @@ export class MenuComponent implements OnInit, OnDestroy {
 
   userTypeDisplay = computed(() => {
     const currentUser = this.currentClient();
-    return currentUser ? this.isClient ? 'Client' : 'Supplier' : 'Guest';
+    return currentUser ? this.isClient ? 'Client' : 'Partner' : 'Guest';
   });
 
   userTypeIcon = computed(() => {
@@ -117,7 +117,7 @@ export class MenuComponent implements OnInit, OnDestroy {
       return 'business';
     }
     
-    if (this.isSupplier) {
+    if (this.isPartner) {
       return 'inventory';
     }
     
@@ -131,7 +131,7 @@ export class MenuComponent implements OnInit, OnDestroy {
     }
     
     // Para usuários com múltiplas roles
-    if (this.isClient && this.isSupplier) {
+    if (this.isClient && this.isPartner) {
       return 'Gerenciar Roles';
     }
     
@@ -140,7 +140,7 @@ export class MenuComponent implements OnInit, OnDestroy {
       return 'Adicionar Role: Fornecedor';
     }
     
-    if (this.isSupplier) {
+    if (this.isPartner) {
       return 'Adicionar Role: Cliente';
     }
     
@@ -155,7 +155,7 @@ export class MenuComponent implements OnInit, OnDestroy {
     }
     
     // Para usuários com múltiplas roles
-    if (this.isClient && this.isSupplier) {
+    if (this.isClient && this.isPartner) {
       return 'badge-multiple';
     }
     
@@ -164,8 +164,8 @@ export class MenuComponent implements OnInit, OnDestroy {
       return 'badge-client';
     }
     
-    if (this.isSupplier) {
-      return 'badge-supplier';
+    if (this.isPartner) {
+      return 'badge-partner';
     }
     
     return 'badge-unknown';
@@ -200,7 +200,7 @@ export class MenuComponent implements OnInit, OnDestroy {
     if (currentUser) {
       let newRoles: UserRole[];
       
-      if (this.isClient && this.isSupplier) {
+      if (this.isClient && this.isPartner) {
         // Se tem múltiplas roles, remover uma
         if (this.isClient) {
           newRoles = ['partner'];
@@ -210,7 +210,7 @@ export class MenuComponent implements OnInit, OnDestroy {
       } else if (this.isClient) {
         // Se é só cliente, adicionar partner
         newRoles = ['client', 'partner'];
-      } else if (this.isSupplier) {
+      } else if (this.isPartner) {
         // Se é só partner, adicionar client
         newRoles = ['client', 'partner'];
       } else {

--- a/nda-manager/src/app/components/share-contract/share-contract.component.html
+++ b/nda-manager/src/app/components/share-contract/share-contract.component.html
@@ -16,7 +16,7 @@
         Share Contract Access
       </h1>
       <p class="page-description">
-        Share confidential contract information with suppliers using their public keys
+        Share confidential contract information with partners using their public keys
       </p>
     </div>
   </div>
@@ -31,7 +31,7 @@
       </div>
       <h2>Access Restricted</h2>
       <p>
-        Only <strong>clients</strong> can share contracts with suppliers.<br>
+        Only <strong>clients</strong> can share contracts with partners.<br>
         You are currently logged in as: <strong>{{ getUserRoleDescription() }}</strong>
       </p>
       <div class="user-info">
@@ -133,31 +133,31 @@
             @if (isFieldInvalid('process_id')) {
               <p class="field-error">{{ getFieldError('process_id') }}</p>
             }
-            <p class="field-help">Select which contract you want to share with the supplier</p>
+            <p class="field-help">Select which contract you want to share with the partner</p>
           </div>
 
-          <!-- Supplier Public Key -->
+          <!-- Partner Public Key -->
           <div class="form-group">
-            <label for="supplier_public_key" class="form-label">
+            <label for="partner_public_key" class="form-label">
               <svg class="label-icon" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z" clip-rule="evenodd"/>
               </svg>
-              Supplier Public Key *
+              Partner Public Key *
             </label>
             <input
               type="text"
-              id="supplier_public_key"
-              formControlName="supplier_public_key"
+              id="partner_public_key"
+              formControlName="partner_public_key"
               class="form-input"
-              [class.invalid]="isFieldInvalid('supplier_public_key')"
+              [class.invalid]="isFieldInvalid('partner_public_key')"
               placeholder="GBSA7ZMGACXOXLS7RDT4OWBWAV6D2A5NIKSCUUUTSNCGDYQD2QEKVYQ4"
               (input)="onPublicKeyInput($event)"
               maxlength="56">
-            @if (isFieldInvalid('supplier_public_key')) {
-              <p class="field-error">{{ getFieldError('supplier_public_key') }}</p>
+            @if (isFieldInvalid('partner_public_key')) {
+              <p class="field-error">{{ getFieldError('partner_public_key') }}</p>
             }
             <p class="field-help">
-              Enter the supplier's Stellar public key (56 characters, starts with 'G')
+              Enter the partner's Stellar public key (56 characters, starts with 'G')
             </p>
           </div>
 
@@ -201,7 +201,7 @@
             <div class="info-icon">🔐</div>
             <div class="info-content">
               <h4>Secure Encryption</h4>
-              <p>Contract data is encrypted using the supplier's public key, ensuring only they can access it.</p>
+              <p>Contract data is encrypted using the partner's public key, ensuring only they can access it.</p>
             </div>
           </div>
           
@@ -209,7 +209,7 @@
             <div class="info-icon">🔑</div>
             <div class="info-content">
               <h4>Public Key Required</h4>
-              <p>You need the supplier's Stellar public key to share the contract securely.</p>
+              <p>You need the partner's Stellar public key to share the contract securely.</p>
             </div>
           </div>
           
@@ -217,7 +217,7 @@
             <div class="info-icon">👥</div>
             <div class="info-content">
               <h4>Access Control</h4>
-              <p>Only the supplier with the corresponding private key can decrypt and view the contract.</p>
+              <p>Only the partner with the corresponding private key can decrypt and view the contract.</p>
             </div>
           </div>
         </div>

--- a/nda-manager/src/app/components/share-contract/share-contract.component.scss
+++ b/nda-manager/src/app/components/share-contract/share-contract.component.scss
@@ -278,7 +278,7 @@
     border: 1px solid #93c5fd;
   }
   
-  &.user-supplier {
+  &.user-partner {
     background: #fef3c7;
     color: #92400e;
     border: 1px solid #fcd34d;

--- a/nda-manager/src/app/components/share-contract/share-contract.component.ts
+++ b/nda-manager/src/app/components/share-contract/share-contract.component.ts
@@ -47,8 +47,8 @@ export class ShareContractComponent implements OnInit {
       return 'user-client';
     }
     
-    if (UserUtils.isSupplier(user)) {
-      return 'user-supplier';
+    if (UserUtils.isPartner(user)) {
+      return 'user-partner';
     }
     
     return 'user-unknown';
@@ -83,7 +83,7 @@ export class ShareContractComponent implements OnInit {
   ) {
     this.shareForm = this.fb.group({
       process_id: ['', [Validators.required]],
-      supplier_public_key: ['', [
+      partner_public_key: ['', [
         Validators.required,
         Validators.minLength(56),
         Validators.maxLength(56),
@@ -118,7 +118,7 @@ export class ShareContractComponent implements OnInit {
         console.log('🔐 Can share contracts:', this.canShare());
 
         if (!this.canShare()) {
-          this.error.set('Only clients can share contracts. You are logged in as a supplier.');
+          this.error.set('Only clients can share contracts. You are logged in as a partner  .');
         }
 
         // Preencher username no formulário
@@ -248,6 +248,6 @@ export class ShareContractComponent implements OnInit {
   onPublicKeyInput(event: Event) {
     const input = event.target as HTMLInputElement;
     const value = input.value.toUpperCase();
-    this.shareForm.patchValue({ supplier_public_key: value });
+    this.shareForm.patchValue({ partner_public_key: value });
   }
 }

--- a/nda-manager/src/app/components/share-contract/share-contract.component.ts
+++ b/nda-manager/src/app/components/share-contract/share-contract.component.ts
@@ -181,7 +181,7 @@ export class ShareContractComponent implements OnInit {
 
       const shareData: ShareRequest = {
         process_id: this.shareForm.get('process_id')?.value,
-        supplier_public_key: this.shareForm.get('supplier_public_key')?.value,
+        partner_public_key: this.shareForm.get('partner_public_key')?.value,
         client_username: user.username
       };
 
@@ -190,7 +190,7 @@ export class ShareContractComponent implements OnInit {
       this.contractService.shareContract(shareData).subscribe({
         next: (response) => {
           console.log('✅ Share successful:', response);
-          this.success.set('Contract shared successfully with supplier!');
+          this.success.set('Contract shared successfully with partner!');
           this.sharing.set(false);
           this.shareForm.reset();
           this.shareForm.patchValue({ client_username: user.username });

--- a/nda-manager/src/app/models/user.model.ts
+++ b/nda-manager/src/app/models/user.model.ts
@@ -38,7 +38,7 @@ export interface UserResponse {
     username: string;
     name: string;
     stellar_public_key: string;
-    roles: UserRoles; // ["client"], ["supplier"], ou ["client", "supplier"]
+    roles: UserRoles; // ["client"], ["partner"], ou ["client", "partner"]
     created_at: string;
 }
 
@@ -70,14 +70,6 @@ export class UserUtils {
      */
     static isPartner(user: User | UserResponse): boolean {
         return this.hasRole(user, 'partner');
-    }
-
-    /**
-     * Legacy method for backwards compatibility
-     * @deprecated Use isPartner() instead
-     */
-    static isSupplier(user: User | UserResponse): boolean {
-        return this.isPartner(user);
     }
 
     /**

--- a/nda-manager/src/app/services/client.service.ts
+++ b/nda-manager/src/app/services/client.service.ts
@@ -11,7 +11,7 @@ export interface Client {
   password: string;
   stellar_public_key?: string;
   isClient(): boolean;
-  isSupplier(): boolean;
+  isPartner(): boolean;
 }
 
 @Injectable({
@@ -31,7 +31,7 @@ export class ClientService {
         password: '', // Password is not stored for security reasons
         stellar_public_key: currentUser.stellar_public_key,
         isClient: () => currentUser.roles.includes('client' as UserRole),
-        isSupplier: () => currentUser.roles.includes('supplier' as UserRole)
+        isPartner: () => currentUser.roles.includes('partner' as UserRole)
       };
     }
     return null;


### PR DESCRIPTION
Replace all instances of "supplier" with "partner" throughout the codebase to reflect updated terminology in the share contract component, user role management, and related functionalities.

## Summary by Sourcery

Replace all instances of the “supplier” role and terminology with “partner” across the entire codebase to align with updated business terminology.

Enhancements:
- Rename the supplier role to partner in user models, services, role checks, and permission logic in both backend and frontend
- Update database schemas, migrations, queries, and table definitions for process_shares and process_accesses to use partner_public_key and partner_id
- Refresh UI components (menu, share-contract, list-contracts), form controls, styles, and example API requests to use partner labels and placeholders
- Revise documentation (README, code comments, examples) to replace supplier references with partner and update related endpoint descriptions